### PR TITLE
fix: script injection in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ steps:
     env:
       parsed_data: ${{ steps.parse.outputs.payload }}
     run: |
-      echo '${{ env.parsed_data }}'
+      echo '$parsed_data'
 ```
 
 The JSON payload that is extracted would look like this:


### PR DESCRIPTION
The script injection reported in #5 is still exploitable as the syntax ${{ }} is used, which still applies a simple string replacement in the evaluated script.

This PR references the env variable in shell directly, which fixes the issue. Documentation can be found here : https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable