### PR TITLE
Fix tag parser when the value contains the end marker

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -20,7 +20,7 @@ module.exports = class Parser {
   get tagRegex() {
     const open = this._config.tag.open
       , close = this._config.tag.close
-      , regexMatch = `${open}(.*)${close}(?:\\s)+(.*)`
+      , regexMatch = `${open}(.*?)${close}(?:\\s)+(.*)`
       ;
 
     const tagRegex = new RegExp(regexMatch, 'sm');

--- a/src/Parser.test.js
+++ b/src/Parser.test.js
@@ -112,6 +112,16 @@ describe('Parser', () => {
       expect(results).to.have.property('template-owner').to.equal('octodemo-resources');
       expect(results).to.have.property('template-repo').to.equal('tmpl_bookstore_v3');
     });
+
+    it('should parse inputs with markers in the data', () => {
+      const parser = new Parser('###', '>>', '<<');
+      const results = parser.parse(loadFileData('example_with_markers.txt'));
+
+      expect(results).to.have.property('demo-repository-owner').to.equal('octodemo');
+      expect(results).to.have.property('template-type').to.equal('repository');
+      expect(results).to.have.property('template-owner').to.equal('octodemo-resources');
+      expect(results).to.have.property('template-repo').to.equal('Markes: >> is start and is << end');
+    });
   });
 });
 

--- a/src/test_data/example_with_markers.txt
+++ b/src/test_data/example_with_markers.txt
@@ -1,0 +1,15 @@
+### >>demo-repository-owner<<
+
+octodemo
+
+### >>template-type<<
+
+repository
+
+### >>template-owner<<
+
+octodemo-resources
+
+### >>template-repo<<
+
+Markes: >> is start and is << end


### PR DESCRIPTION
This pull request fix the parse of inputs when the value contains the tags end marker.
See the added test case for a sample.